### PR TITLE
Load GCode Dropdown Updates

### DIFF
--- a/src/tablet.js
+++ b/src/tablet.js
@@ -2905,11 +2905,9 @@ function populateTabletFileSelector(files, path) {
     var extList = gCodeFileExtensions.split(';');
     files = files.filter(file => extList.includes(file.name.split('.').pop()) || file.size == -1);
 
-    // Sort files by name with directories first
+    // Sort files by name
     files = files.sort(function(a, b) {
-        var sizeA = (a.size == -1 ? 1 : 0);
-        var sizeB = (b.size == -1 ? 1 : 0);
-        return (sizeB - sizeA) || a.name.localeCompare(b.name);
+        return a.name.localeCompare(b.name);
     });
 
     files_file_list = files;


### PR DESCRIPTION
Made the following changes to the GCode Dropdown:

- Resolved issue where files were not listed when selecting a folder
- Updated to allow for navigating to parent directory
- Updated to sort the files by name with directories first
- Updated to filter files list to only directories or gcode extensions as defined in preferences.json.  Same as what is used by the Files panel on the dashboard.
![image](https://github.com/MitchBradley/WebUI-tablet-extension/assets/28162926/ed2828d3-da7e-4371-b5a9-1608bd8f7388)

Tested against FluidNC 3.7.17 running build of WebUI v3 from https://github.com/michmela44/ESP3D-WEBUI/tree/3.0-FluidNCDev on Jackpot CNC Controller.
