### PR TITLE
Panel Support and Machine Bounding Box

### DIFF
--- a/src/9-tablet.js
+++ b/src/9-tablet.js
@@ -668,6 +668,7 @@ function tabletInit() {
     initDisplayer()
     requestModes()
     askCapabilities()
+    askMachineBbox()
     downloadPreferences()
 }
 
@@ -1288,7 +1289,7 @@ function loadApp() {
                     div('dropdown', 'dropdown  dropdown-right', [
                         menubutton('btn-dropdown', 'btn-tablet dropdown-toggle', "Menu"), // {"attributes":{"tabindex":"0"}}
                         element('ul', 'tablet-dropdown-menu', 'menu', [
-                            mi("Full Screen", menuFullScreen)
+                            mi("Full Screen", menuFullScreen),
                             mi("Homing", menuHomeAll),
                             mi("Home A", menuHomeA),
                             mi("Spindle Off", menuSpindleOff),
@@ -1389,6 +1390,7 @@ function loadApp() {
                 ]),
             ]),
             input('uploadBtn', 'd-none', 'file', null, internalUploadFile, ""),
+            button('fsBtn', 'btn-tablet d-none', "[ ]" , "Full Screen",  menuFullScreen, '')
         ])
 
     document.body.appendChild(app)

--- a/src/tablet.css
+++ b/src/tablet.css
@@ -238,3 +238,68 @@
 /* No decimal points allowed */
 #numBWrap.noDec .dot { display: none; }
 #numBWrap.noDec .zero { grid-column: span 3; }
+
+/* Panel Extension */
+@media (max-width: 720px) {
+  #tablettab {
+    font-size: 16px;
+    margin: 0;
+    padding: 5px;
+  }
+
+  #nav-panel, #axis-position, #setAxis, #control-pad,
+  #messagepane #gcode-states, #messagepane #messages,
+  #expand-button,
+  #mdifiles div:nth-child(-n+4), /* GCode Command and MDI buttons */
+  #mdifiles div:nth-child(6),    /* Upld button */
+  #mdifiles div:nth-child(8)     /* Refr button */
+  {
+    display: none;
+  }
+
+  #mdifiles div:nth-child(5) {
+    width: 70%;
+  }
+
+  #mdifiles div:nth-child(7) {
+    width: 18%;
+  }
+
+  #mdifiles.area {
+    padding-top: 3px !important;
+  }
+
+  #previewpane {
+    position: absolute;
+    top: 152px;
+    width: 97%;
+    height: 358px;
+  }
+
+  #gcode {
+    position: absolute;
+    width: 96%;
+    height: 90px;
+    font-family: "SF Mono", "Segoe UI Mono", "Roboto Mono", Menlo, Courier, monospace;
+    font-size: 14px;
+  }
+
+  #gcode, #mdifiles {
+    background-color: inherit;
+  }
+
+  .btn-tablet {
+    height: auto;
+    font-size: 16px;
+  }
+
+  #fsBtn {
+    display: block !important;
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-top: 10px;
+    margin-right: 10px;
+    width: 35px;
+  }
+}


### PR DESCRIPTION
Added support for Panel mode on the dashboard.  This is implemented through adding media styles for widths <= 720px.  A fullscreen button ("[ ]") is added in Panel mode which will display the full tablet UI.

Additionally, added a call to the existing function to get the machine bounding box.  Previously, it was using default values which in my case caused the gcode to draw outside the box.

![gcodeviz](https://github.com/MitchBradley/WebUI-tablet-extension/assets/28162926/20f6c48d-f335-40b4-af80-3192051f1889)
